### PR TITLE
[#19] feat: zustand 설치 및 운행일지 목록 api 연결

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8080/api/:path*',
+      },
+    ]
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.1.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1383,7 +1384,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2412,7 +2413,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6132,6 +6133,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.1.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/logs/page.tsx
+++ b/src/app/logs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import PageHeader from "@/components/common/PageHeader";
 import { VehicleLogList } from "@/components/logs/VehicleLogList";
 import { VehicleLogFilter } from "@/components/logs/VehicleLogFilter";
@@ -9,6 +9,7 @@ import { useTheme } from "@/contexts/ThemeContext";
 import { ArrowDownTrayIcon } from "@heroicons/react/24/outline";
 import { downloadExcel } from "@/lib/utils";
 import VehicleLogDetailSlidePanel from "@/components/logs/VehicleLogDetailSlidePanel";
+import { useCarLogsStore } from "@/lib/carLogsStore";
 
 export default function LogsPage() {
   const { currentTheme } = useTheme();
@@ -16,7 +17,12 @@ export default function LogsPage() {
   const [filter, setFilter] = useState<FilterType>({});
   const [selectedLog, setSelectedLog] = useState<VehicleLog | null>(null);
   const [isSlidePanelOpen, setIsSlidePanelOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  
+  const { fetchCarLogs, isLoading, carLogs } = useCarLogsStore();
+  
+  useEffect(() => {
+    fetchCarLogs();
+  }, [fetchCarLogs]);
   
   const handleFilterChange = (newFilter: FilterType) => {
     setFilter(newFilter);
@@ -27,21 +33,7 @@ export default function LogsPage() {
   };
 
   const handleSearch = async () => {
-    setIsLoading(true);
-    
-    try {
-      console.log('검색 요청:', { 
-        term: searchTerm,
-        startDate: filter.startDate, 
-        endDate: filter.endDate
-      });
-      
-      await new Promise(resolve => setTimeout(resolve, 500));
-    } catch (error) {
-      console.error('검색 중 오류 발생:', error);
-    } finally {
-      setIsLoading(false);
-    }
+    await fetchCarLogs();
   };
 
   const handleLogSelect = (log: VehicleLog) => {
@@ -73,7 +65,7 @@ export default function LogsPage() {
           description="차량 운행 기록을 관리하고 조회할 수 있습니다." 
         />
         <button
-          onClick={() => handleExportExcel([])} // VehicleLogList에서 실제 데이터로 교체됨
+          onClick={() => handleExportExcel([])} 
           className={`flex items-center px-3 py-1.5 rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-all duration-200 shadow-sm`}
         >
           <ArrowDownTrayIcon className="h-4 w-4 mr-1.5" />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,33 @@
+// API 엔드포인트 기본 URL
+export const API_BASE_URL = '/api';
+
+// API 요청 함수
+export const fetchApi = async <T>(endpoint: string, queryParams?: Record<string, any>, options?: RequestInit): Promise<T> => {
+  const token = localStorage.getItem('authToken') || '';
+  let url = `${API_BASE_URL}${endpoint}`;
+  
+  // 쿼리 파라미터 추가
+  if (queryParams && Object.keys(queryParams).length > 0) {
+    const queryString = Object.entries(queryParams)
+      .filter(([_, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+      .join('&');
+      
+    url = `${url}?${queryString}`;
+  }
+  
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+  
+  if (!response.ok) {
+    throw new Error(`API 요청 실패: ${response.status}`);
+  }
+  
+  return response.json();
+}; 

--- a/src/lib/carLogsStore.ts
+++ b/src/lib/carLogsStore.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+import { CarLogResponse, CarLogsParams } from '@/types/logs';
+import { API_BASE_URL, fetchApi } from '@/lib/api';
+
+interface CarLogsState {
+  carLogs: CarLogResponse[];
+  isLoading: boolean;
+  error: string | null;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+  
+  // Actions
+  fetchCarLogs: (params?: Partial<CarLogsParams>) => Promise<void>;
+  setPage: (page: number) => void;
+  setPageSize: (size: number) => void;
+}
+
+export const useCarLogsStore = create<CarLogsState>((set, get) => ({
+  carLogs: [],
+  isLoading: false,
+  error: null,
+  currentPage: 0,
+  totalPages: 1,
+  pageSize: 10,
+  
+  fetchCarLogs: async (params) => {
+    try {
+      set({ isLoading: true, error: null });
+      
+      const { currentPage, pageSize } = get();
+      const page = params?.page !== undefined ? params.page : currentPage;
+      const size = params?.size !== undefined ? params.size : pageSize;
+      
+      const data = await fetchApi<CarLogResponse[]>('/carLogs', { page, size });
+      
+      set({ 
+        carLogs: data,
+        currentPage: page,
+        // 백엔드가 총 페이지 수를 제공하는 경우 추가
+        // totalPages: data.totalPages || 1,
+        isLoading: false
+      });
+    } catch (error) {
+      console.error('운행일지 데이터 가져오기 실패:', error);
+      set({ 
+        error: error instanceof Error ? error.message : '운행일지 데이터를 가져오는 중 오류가 발생했습니다',
+        isLoading: false
+      });
+    }
+  },
+  
+  setPage: (page) => {
+    set({ currentPage: page });
+    get().fetchCarLogs({ page });
+  },
+  
+  setPageSize: (size) => {
+    set({ pageSize: size, currentPage: 0 });
+    get().fetchCarLogs({ page: 0, size });
+  },
+})); 

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -15,7 +15,7 @@ export interface VehicleLog {
   totalDistance: number;
   driveType: DriveType;
   driver: Driver | null;
-  note?: string;
+  note?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -26,4 +26,22 @@ export interface VehicleLogFilter {
   endDate?: string;
   driveType?: DriveType;
   driverId?: string;
+}
+
+export interface CarLogResponse {
+  logId: number;
+  mdn: string;
+  onTime: string;
+  offTime: string;
+  onMileage: number;
+  offMileage: number;
+  totalMileage: number | null;
+  driveType: string;
+  driver: string;
+  description: string | null;
+}
+
+export interface CarLogsParams {
+  page: number;
+  size: number;
 } 


### PR DESCRIPTION
close #19

## 📝 작업 내용

> zustand 설치 및 운행 목록 api 연결
- zustand 설치 
- zustand를 활용하여 api를 연동하는 기본 구조 세팅을 위해 운행일지 목록 api를 우선 연결했습니다.

# 📍 기타 (선택)

> 운행일지 페이지에 나머지 api는 별도의 이슈, 브랜치에서 작업 예정
