### PR TITLE
[#23] feat: 운행일지 페이지 API 연결

### DIFF
--- a/src/app/logs/page.tsx
+++ b/src/app/logs/page.tsx
@@ -18,7 +18,7 @@ export default function LogsPage() {
   const [selectedLog, setSelectedLog] = useState<VehicleLog | null>(null);
   const [isSlidePanelOpen, setIsSlidePanelOpen] = useState(false);
   
-  const { fetchCarLogs, isLoading, carLogs, deleteCarLog } = useCarLogsStore();
+  const { fetchCarLogs, isLoading, carLogs, deleteCarLog, currentFilter } = useCarLogsStore();
   
   useEffect(() => {
     fetchCarLogs();
@@ -33,7 +33,14 @@ export default function LogsPage() {
   };
 
   const handleSearch = async () => {
-    await fetchCarLogs();
+    console.log('검색 시작, 현재 필터:', filter);
+    // filter에 있는 데이터로 검색을 수행함
+    await fetchCarLogs({
+      vehicleNumber: filter.vehicleNumber,
+      startDate: filter.startDate,
+      endDate: filter.endDate
+    });
+    console.log('검색 완료, 필터 적용됨');
   };
 
   const handleLogSelect = (log: VehicleLog) => {
@@ -112,18 +119,20 @@ export default function LogsPage() {
 
       <div className="mt-4">
         <VehicleLogFilter 
-          filter={filter} 
-          onFilterChange={handleFilterChange} 
-          searchTerm={searchTerm}
-          onSearchChange={handleSearchChange}
-          onSearch={handleSearch}
+          initialFilter={currentFilter as FilterType}
+          onApplyFilter={() => {
+            // 필터 적용 시 첫 페이지부터 데이터 가져오기
+            fetchCarLogs({ page: 0 });
+          }}
         />
         <div className="mt-4">
           <VehicleLogList 
-            filter={filter} 
-            searchTerm={searchTerm} 
+            filter={currentFilter as FilterType}
             onExport={handleExportExcel}
             onLogSelect={handleLogSelect}
+            isSlideOpen={isSlidePanelOpen}
+            onCloseSlide={handleCloseSidePanel}
+            selectedLog={selectedLog}
             isLoading={isLoading}
           />
         </div>

--- a/src/app/logs/page.tsx
+++ b/src/app/logs/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import PageHeader from "@/components/common/PageHeader";
 import { VehicleLogList } from "@/components/logs/VehicleLogList";
 import { VehicleLogFilter } from "@/components/logs/VehicleLogFilter";
-import { VehicleLogFilter as FilterType, VehicleLog } from "@/types/logs";
+import { VehicleLogFilter as FilterType, VehicleLog, DriveType } from "@/types/logs";
 import { useTheme } from "@/contexts/ThemeContext";
 import { ArrowDownTrayIcon } from "@heroicons/react/24/outline";
 import { downloadExcel } from "@/lib/utils";
@@ -65,7 +65,25 @@ export default function LogsPage() {
           description="차량 운행 기록을 관리하고 조회할 수 있습니다." 
         />
         <button
-          onClick={() => handleExportExcel([])} 
+          onClick={() => {
+            // VehicleLogList 컴포넌트에서 filteredLogs를 가져올 수 없으므로 
+            // carLogs를 VehicleLog 형식으로 변환해서 전달
+            const mappedLogs = carLogs.map(log => ({
+              id: log.logId.toString(),
+              vehicleNumber: log.mdn,
+              startTime: log.onTime,
+              endTime: log.offTime,
+              startMileage: log.onMileage,
+              endMileage: log.offMileage,
+              totalDistance: log.totalMileage || log.offMileage - log.onMileage,
+              driveType: (log.driveType === 'WORK' ? 'CORPORATE' : 'PERSONAL') as DriveType,
+              driver: log.driver ? { id: '1', name: log.driver } : null,
+              note: log.description,
+              createdAt: log.onTime,
+              updatedAt: log.offTime
+            }));
+            handleExportExcel(mappedLogs);
+          }} 
           className={`flex items-center px-3 py-1.5 rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-all duration-200 shadow-sm`}
         >
           <ArrowDownTrayIcon className="h-4 w-4 mr-1.5" />

--- a/src/components/logs/VehicleLogList.tsx
+++ b/src/components/logs/VehicleLogList.tsx
@@ -17,290 +17,6 @@ interface VehicleLogListProps {
   isLoading?: boolean;
 }
 
-// 임시 데이터 - 실제로는 API에서 가져와야 함
-const mockData: VehicleLog[] = [
-  {
-    id: '1',
-    vehicleNumber: '서울 123가 4567',
-    startTime: '2024-03-20T09:00:00Z',
-    endTime: '2024-03-20T18:00:00Z',
-    startMileage: 50000,
-    endMileage: 50150,
-    totalDistance: 150,
-    driveType: 'CORPORATE',
-    driver: { id: '1', name: '홍길동' },
-    note: '업무 출장',
-    createdAt: '2024-03-20T09:00:00Z',
-    updatedAt: '2024-03-20T18:00:00Z',
-  },
-  {
-    id: '2',
-    vehicleNumber: '경기 456나 7890',
-    startTime: '2024-03-21T08:30:00Z',
-    endTime: '2024-03-21T17:30:00Z',
-    startMileage: 35000,
-    endMileage: 35180,
-    totalDistance: 180,
-    driveType: 'PERSONAL',
-    driver: { id: '2', name: '김철수' },
-    note: '개인 용무',
-    createdAt: '2024-03-21T08:30:00Z',
-    updatedAt: '2024-03-21T17:30:00Z',
-  },
-  {
-    id: '3',
-    vehicleNumber: '부산 789다 1234',
-    startTime: '2024-03-22T10:00:00Z',
-    endTime: '2024-03-22T16:00:00Z',
-    startMileage: 42000,
-    endMileage: 42120,
-    totalDistance: 120,
-    driveType: 'UNREGISTERED',
-    driver: null,
-    note: '임시 운행',
-    createdAt: '2024-03-22T10:00:00Z',
-    updatedAt: '2024-03-22T16:00:00Z',
-  },
-  {
-    id: '4',
-    vehicleNumber: '서울 123가 4567',
-    startTime: '2024-03-23T09:00:00Z',
-    endTime: '2024-03-23T18:00:00Z',
-    startMileage: 50150,
-    endMileage: 50300,
-    totalDistance: 150,
-    driveType: 'CORPORATE',
-    driver: { id: '1', name: '홍길동' },
-    note: '거래처 방문',
-    createdAt: '2024-03-23T09:00:00Z',
-    updatedAt: '2024-03-23T18:00:00Z',
-  },
-  {
-    id: '5',
-    vehicleNumber: '인천 012라 5678',
-    startTime: '2024-03-24T08:00:00Z',
-    endTime: '2024-03-24T17:00:00Z',
-    startMileage: 27000,
-    endMileage: 27250,
-    totalDistance: 250,
-    driveType: 'PERSONAL',
-    driver: { id: '3', name: '이영희' },
-    note: '주말 여행',
-    createdAt: '2024-03-24T08:00:00Z',
-    updatedAt: '2024-03-24T17:00:00Z',
-  },
-  {
-    id: '6',
-    vehicleNumber: '대전 234마 9012',
-    startTime: '2024-03-25T09:30:00Z',
-    endTime: '2024-03-25T16:30:00Z',
-    startMileage: 62000,
-    endMileage: 62130,
-    totalDistance: 130,
-    driveType: 'CORPORATE',
-    driver: { id: '4', name: '박지민' },
-    note: '본사 방문',
-    createdAt: '2024-03-25T09:30:00Z',
-    updatedAt: '2024-03-25T16:30:00Z',
-  },
-  {
-    id: '7',
-    vehicleNumber: '광주 345바 3456',
-    startTime: '2024-03-26T10:00:00Z',
-    endTime: '2024-03-26T15:00:00Z',
-    startMileage: 45000,
-    endMileage: 45220,
-    totalDistance: 220,
-    driveType: 'PERSONAL',
-    driver: { id: '5', name: '정수민' },
-    note: '가족 방문',
-    createdAt: '2024-03-26T10:00:00Z',
-    updatedAt: '2024-03-26T15:00:00Z',
-  },
-  {
-    id: '8',
-    vehicleNumber: '대구 456사 6789',
-    startTime: '2024-03-27T08:00:00Z',
-    endTime: '2024-03-27T18:00:00Z',
-    startMileage: 38000,
-    endMileage: 38300,
-    totalDistance: 300,
-    driveType: 'CORPORATE',
-    driver: { id: '6', name: '최현우' },
-    note: '고객사 미팅',
-    createdAt: '2024-03-27T08:00:00Z',
-    updatedAt: '2024-03-27T18:00:00Z',
-  },
-  {
-    id: '9',
-    vehicleNumber: '부산 789다 1234',
-    startTime: '2024-03-28T09:00:00Z',
-    endTime: '2024-03-28T17:00:00Z',
-    startMileage: 42120,
-    endMileage: 42270,
-    totalDistance: 150,
-    driveType: 'UNREGISTERED',
-    driver: null,
-    note: '차량 점검',
-    createdAt: '2024-03-28T09:00:00Z',
-    updatedAt: '2024-03-28T17:00:00Z',
-  },
-  {
-    id: '10',
-    vehicleNumber: '서울 123가 4567',
-    startTime: '2024-03-29T08:30:00Z',
-    endTime: '2024-03-29T18:30:00Z',
-    startMileage: 50300,
-    endMileage: 50450,
-    totalDistance: 150,
-    driveType: 'CORPORATE',
-    driver: { id: '1', name: '홍길동' },
-    note: '프로젝트 미팅',
-    createdAt: '2024-03-29T08:30:00Z',
-    updatedAt: '2024-03-29T18:30:00Z',
-  },
-  {
-    id: '11',
-    vehicleNumber: '경기 456나 7890',
-    startTime: '2024-03-30T10:00:00Z',
-    endTime: '2024-03-30T16:00:00Z',
-    startMileage: 35180,
-    endMileage: 35280,
-    totalDistance: 100,
-    driveType: 'PERSONAL',
-    driver: { id: '2', name: '김철수' },
-    note: '쇼핑',
-    createdAt: '2024-03-30T10:00:00Z',
-    updatedAt: '2024-03-30T16:00:00Z',
-  },
-  {
-    id: '12',
-    vehicleNumber: '인천 012라 5678',
-    startTime: '2024-03-31T09:00:00Z',
-    endTime: '2024-03-31T19:00:00Z',
-    startMileage: 27250,
-    endMileage: 27450,
-    totalDistance: 200,
-    driveType: 'PERSONAL',
-    driver: { id: '3', name: '이영희' },
-    note: '친구 방문',
-    createdAt: '2024-03-31T09:00:00Z',
-    updatedAt: '2024-03-31T19:00:00Z',
-  },
-  {
-    id: '13',
-    vehicleNumber: '대전 234마 9012',
-    startTime: '2024-04-01T08:00:00Z',
-    endTime: '2024-04-01T17:00:00Z',
-    startMileage: 62130,
-    endMileage: 62230,
-    totalDistance: 100,
-    driveType: 'CORPORATE',
-    driver: { id: '4', name: '박지민' },
-    note: '정기 회의',
-    createdAt: '2024-04-01T08:00:00Z',
-    updatedAt: '2024-04-01T17:00:00Z',
-  },
-  {
-    id: '14',
-    vehicleNumber: '광주 345바 3456',
-    startTime: '2024-04-02T09:30:00Z',
-    endTime: '2024-04-02T15:30:00Z',
-    startMileage: 45220,
-    endMileage: 45350,
-    totalDistance: 130,
-    driveType: 'PERSONAL',
-    driver: { id: '5', name: '정수민' },
-    note: '개인 용무',
-    createdAt: '2024-04-02T09:30:00Z',
-    updatedAt: '2024-04-02T15:30:00Z',
-  },
-  {
-    id: '15',
-    vehicleNumber: '대구 456사 6789',
-    startTime: '2024-04-03T08:30:00Z',
-    endTime: '2024-04-03T18:30:00Z',
-    startMileage: 38300,
-    endMileage: 38450,
-    totalDistance: 150,
-    driveType: 'CORPORATE',
-    driver: { id: '6', name: '최현우' },
-    note: '업무 출장',
-    createdAt: '2024-04-03T08:30:00Z',
-    updatedAt: '2024-04-03T18:30:00Z',
-  },
-  {
-    id: '16',
-    vehicleNumber: '서울 567아 7890',
-    startTime: '2024-04-04T10:00:00Z',
-    endTime: '2024-04-04T17:00:00Z',
-    startMileage: 18000,
-    endMileage: 18150,
-    totalDistance: 150,
-    driveType: 'CORPORATE',
-    driver: { id: '7', name: '강민준' },
-    note: '고객 미팅',
-    createdAt: '2024-04-04T10:00:00Z',
-    updatedAt: '2024-04-04T17:00:00Z',
-  },
-  {
-    id: '17',
-    vehicleNumber: '부산 678자 8901',
-    startTime: '2024-04-05T09:00:00Z',
-    endTime: '2024-04-05T16:00:00Z',
-    startMileage: 55000,
-    endMileage: 55200,
-    totalDistance: 200,
-    driveType: 'UNREGISTERED',
-    driver: null,
-    note: '차량 테스트',
-    createdAt: '2024-04-05T09:00:00Z',
-    updatedAt: '2024-04-05T16:00:00Z',
-  },
-  {
-    id: '18',
-    vehicleNumber: '경기 789차 9012',
-    startTime: '2024-04-06T08:00:00Z',
-    endTime: '2024-04-06T15:00:00Z',
-    startMileage: 23000,
-    endMileage: 23100,
-    totalDistance: 100,
-    driveType: 'PERSONAL',
-    driver: { id: '8', name: '윤서연' },
-    note: '쇼핑',
-    createdAt: '2024-04-06T08:00:00Z',
-    updatedAt: '2024-04-06T15:00:00Z',
-  },
-  {
-    id: '19',
-    vehicleNumber: '인천 890카 0123',
-    startTime: '2024-04-07T09:30:00Z',
-    endTime: '2024-04-07T17:30:00Z',
-    startMileage: 72000,
-    endMileage: 72250,
-    totalDistance: 250,
-    driveType: 'CORPORATE',
-    driver: { id: '9', name: '임준호' },
-    note: '업무 미팅',
-    createdAt: '2024-04-07T09:30:00Z',
-    updatedAt: '2024-04-07T17:30:00Z',
-  },
-  {
-    id: '20',
-    vehicleNumber: '대전 901타 1234',
-    startTime: '2024-04-08T10:00:00Z',
-    endTime: '2024-04-08T16:00:00Z',
-    startMileage: 41000,
-    endMileage: 41120,
-    totalDistance: 120,
-    driveType: 'PERSONAL',
-    driver: { id: '10', name: '한지훈' },
-    note: '가족 여행',
-    createdAt: '2024-04-08T10:00:00Z',
-    updatedAt: '2024-04-08T16:00:00Z',
-  },
-];
-
 export function VehicleLogList({ 
   filter, 
   searchTerm = '',
@@ -326,55 +42,65 @@ export function VehicleLogList({
     setPage 
   } = useCarLogsStore();
 
-  // 컴포넌트 마운트 시 데이터 가져오기
-  useEffect(() => {
-    fetchCarLogs({ page: 0, size: 10 });
-  }, [fetchCarLogs]);
-
   // API 응답 데이터를 VehicleLog 형식으로 변환
   const mappedLogs = useMemo(() => {
-    return carLogs.map(log => ({
-      id: log.logId.toString(),
-      vehicleNumber: log.mdn,
-      startTime: log.onTime,
-      endTime: log.offTime,
-      startMileage: log.onMileage,
-      endMileage: log.offMileage,
-      totalDistance: log.totalMileage || log.offMileage - log.onMileage,
-      driveType: (log.driveType === 'WORK' ? 'CORPORATE' : 'PERSONAL') as DriveType,
-      driver: log.driver ? { id: '1', name: log.driver } : null,
-      note: log.description,
-      createdAt: log.onTime,
-      updatedAt: log.offTime
-    }));
+    return carLogs.map(log => {
+      // API 응답의 driveType을 변환
+      let driveType: DriveType = 'UNREGISTERED';
+      if (log.driveType === 'COMMUTE' || log.driveType === 'WORK') {
+        driveType = log.driveType as DriveType;
+      }
+      
+      const mappedLog = {
+        id: log.logId.toString(),
+        vehicleNumber: log.mdn,
+        startTime: log.onTime,
+        endTime: log.offTime,
+        startMileage: log.onMileage,
+        endMileage: log.offMileage,
+        totalDistance: log.totalMileage || log.offMileage - log.onMileage,
+        driveType: driveType,
+        driver: log.driver ? { id: '1', name: log.driver } : null,
+        note: log.description,
+        createdAt: log.onTime,
+        updatedAt: log.offTime
+      };
+      
+      return mappedLog;
+    });
   }, [carLogs]);
 
-  // 필터링된 로그 데이터
+  // 검색어와 필터를 적용한 로그 목록
   const filteredLogs = useMemo(() => {
     return mappedLogs.filter(log => {
-      // 검색어 필터링
-      if (searchTerm && !log.vehicleNumber.toLowerCase().includes(searchTerm.toLowerCase()) &&
-          !(log.driver?.name?.toLowerCase().includes(searchTerm.toLowerCase()) || false) &&
-          !(log.note?.toLowerCase().includes(searchTerm.toLowerCase()) || false)) {
-        return false;
-      }
+      // 차량 번호 검색
+      const matchesSearch = searchTerm 
+        ? log.vehicleNumber.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          (log.driver?.name && log.driver.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
+          (log.note && log.note.toLowerCase().includes(searchTerm.toLowerCase()))
+        : true;
       
-      // 날짜 범위 필터링
-      if (filter.startDate && new Date(log.startTime) < new Date(filter.startDate)) {
-        return false;
-      }
+      // 드라이브 타입 필터
+      const matchesDriveType = !filter.driveType || filter.driveType === log.driveType;
       
-      if (filter.endDate && new Date(log.endTime) > new Date(filter.endDate)) {
-        return false;
-      }
+      // 날짜 범위 필터 (시작일)
+      const startDateMatch = filter.startDate
+        ? new Date(log.startTime) >= new Date(filter.startDate)
+        : true;
       
-      return true;
+      // 날짜 범위 필터 (종료일)
+      const endDateMatch = filter.endDate
+        ? new Date(log.startTime) <= new Date(filter.endDate)
+        : true;
+        
+      return matchesSearch && matchesDriveType && startDateMatch && endDateMatch;
     });
-  }, [filter, searchTerm, mappedLogs]);
+  }, [mappedLogs, filter, searchTerm]);
 
-  // 페이지 변경 핸들러
-  const handlePageChange = (page: number) => {
-    setPage(page);
+  // 페이지 변경 처리 함수
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+    fetchCarLogs({ page: newPage, size: pageSize });
   };
 
   const handleLogClick = (log: VehicleLog) => {
@@ -393,9 +119,9 @@ export function VehicleLogList({
   // 드라이브 타입에 따른 배경색 클래스
   const getDriveTypeClass = (type: DriveType) => {
     switch (type) {
-      case 'PERSONAL':
+      case 'COMMUTE':
         return 'bg-blue-50 text-blue-700 dark:bg-blue-50 dark:text-blue-700';
-      case 'CORPORATE':
+      case 'WORK':
         return 'bg-teal-50 text-teal-700 dark:bg-teal-50 dark:text-teal-700';
       case 'UNREGISTERED':
         return 'bg-slate-50 text-slate-700 dark:bg-slate-50 dark:text-slate-700';
@@ -406,8 +132,8 @@ export function VehicleLogList({
 
   const getDriveTypeLabel = (type: DriveType) => {
     const types = {
-      PERSONAL: '개인',
-      CORPORATE: '법인',
+      COMMUTE: '출퇴근',
+      WORK: '업무',
       UNREGISTERED: '미등록',
     } as const;
     return types[type];
@@ -553,8 +279,8 @@ export function VehicleLogList({
           isOpen={isLocalSlideOpen}
           onClose={handleCloseLocalSlide}
           log={localSelectedLog}
-          onDelete={(id) => console.log(`삭제할 운행 기록 ID: ${id}`)}
-          onUpdate={(log) => console.log('운행 기록 업데이트:', log)}
+          onDelete={(id) => {}}
+          onUpdate={(log) => {}}
         />
       )}
     </>

--- a/src/components/logs/VehicleLogList.tsx
+++ b/src/components/logs/VehicleLogList.tsx
@@ -501,8 +501,8 @@ export function VehicleLogList({
                     <td className={`px-5 py-3.5 whitespace-nowrap text-sm ${currentTheme.text} dark:text-gray-800`}>
                       {log.driver?.name || '미등록'}
                     </td>
-                    <td className={`px-5 py-3.5 whitespace-nowrap text-sm ${currentTheme.text} dark:text-gray-800`}>
-                      {log.note || '-'}
+                    <td className={`px-5 py-3.5 whitespace-nowrap text-sm ${currentTheme.text} dark:text-gray-800`} title={log.note || '-'}>
+                      {log.note ? (log.note.length > 10 ? `${log.note.substring(0, 10)}...` : log.note) : '-'}
                     </td>
                   </tr>
                 ))

--- a/src/components/logs/VehicleLogList.tsx
+++ b/src/components/logs/VehicleLogList.tsx
@@ -260,9 +260,35 @@ export function VehicleLogList({
                   <span className="sr-only">이전</span>
                   <ChevronLeftIcon className="h-5 w-5" aria-hidden="true" />
                 </button>
+                
+                {(() => {
+                  const totalPages = Math.ceil(carLogs.length / pageSize);
+                  let startPage = Math.max(0, currentPage - 2);
+                  let endPage = Math.min(totalPages - 1, startPage + 4);
+        
+                  if (endPage - startPage < 4) {
+                    startPage = Math.max(0, endPage - 4);
+                  }
+                  
+                  return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i).map((page) => (
+                    <button
+                      key={page}
+                      onClick={() => handlePageChange(page)}
+                      className={`relative inline-flex items-center px-3 py-1.5 border ${
+                        currentPage === page
+                          ? `z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-indigo-100 dark:border-indigo-500 dark:text-indigo-800`
+                          : `${currentTheme.border} ${currentTheme.cardBg} ${currentTheme.text} hover:bg-gray-50 dark:hover:bg-gray-200 dark:text-gray-800`
+                      } text-sm font-medium`}
+                    >
+                      {page + 1}
+                    </button>
+                  ));
+                })()}
+                
                 <button
                   onClick={() => handlePageChange(currentPage + 1)}
-                  className={`relative inline-flex items-center px-2 py-2 rounded-r-md border ${currentTheme.border} ${currentTheme.cardBg} text-sm font-medium ${currentTheme.text} hover:bg-gray-50`}
+                  disabled={currentPage >= Math.ceil(carLogs.length / pageSize) - 1}
+                  className={`relative inline-flex items-center px-2 py-2 rounded-r-md border ${currentTheme.border} ${currentTheme.cardBg} text-sm font-medium ${currentPage >= Math.ceil(carLogs.length / pageSize) - 1 ? 'text-gray-300 cursor-not-allowed' : `${currentTheme.text} hover:bg-gray-50`}`}
                 >
                   <span className="sr-only">다음</span>
                   <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -13,14 +13,37 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
     const { currentTheme } = useTheme();
     
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const date = e.target.value ? new Date(e.target.value) : undefined;
-      onChange?.(date);
+      if (e.target.value) {
+        // 'YYYY-MM-DD' 형식의 문자열로부터 Date 객체 생성
+        const dateString = e.target.value;
+        
+        // 날짜를 KST(한국 시간)으로 처리
+        const [year, month, day] = dateString.split('-').map(Number);
+        
+        // 날짜 부분만 사용하여 현지 시간으로 Date 객체 생성
+        const date = new Date(year, month - 1, day, 0, 0, 0);
+        
+        onChange?.(date);
+      } else {
+        onChange?.(undefined);
+      }
+    };
+
+    // 입력 필드에 표시할 날짜 문자열 생성 (YYYY-MM-DD 형식)
+    const getDateString = (date?: Date): string => {
+      if (!date) return '';
+      
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      
+      return `${year}-${month}-${day}`;
     };
 
     return (
       <Input
-        type="datetime-local"
-        value={value?.toISOString().slice(0, 16) || ''}
+        type="date"
+        value={value ? getDateString(value) : ''}
         onChange={handleChange}
         className={`border ${currentTheme.border} ${className}`}
         ref={ref}

--- a/src/lib/carLogsStore.ts
+++ b/src/lib/carLogsStore.ts
@@ -2,6 +2,13 @@ import { create } from 'zustand';
 import { CarLogResponse, CarLogsParams } from '@/types/logs';
 import { API_BASE_URL, fetchApi } from '@/lib/api';
 
+// 업데이트용 타입 정의
+interface CarLogUpdateData {
+  driveType: string | null;
+  driver: string;
+  description: string;
+}
+
 interface CarLogsState {
   carLogs: CarLogResponse[];
   isLoading: boolean;
@@ -12,6 +19,8 @@ interface CarLogsState {
   
   // Actions
   fetchCarLogs: (params?: Partial<CarLogsParams>) => Promise<void>;
+  updateCarLog: (logId: number, data: CarLogUpdateData) => Promise<{ success: boolean; message: string }>;
+  deleteCarLog: (logId: number) => Promise<{ success: boolean; message: string }>;
   setPage: (page: number) => void;
   setPageSize: (size: number) => void;
 }
@@ -47,6 +56,89 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
         error: error instanceof Error ? error.message : '운행일지 데이터를 가져오는 중 오류가 발생했습니다',
         isLoading: false
       });
+    }
+  },
+  
+  updateCarLog: async (logId, data) => {
+    try {
+      set({ isLoading: true, error: null });
+      
+      // PUT 요청으로 운행 기록 수정
+      const response = await fetch(`${API_BASE_URL}/carLogs/${logId}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('authToken') || ''}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data)
+      });
+      
+      if (!response.ok) {
+        throw new Error(`API 요청 실패: ${response.status}`);
+      }
+      
+      // 응답이 단순 문자열인 경우 처리
+      const responseText = await response.text();
+      
+      // 업데이트 후 목록 새로고침
+      await get().fetchCarLogs();
+      
+      // 서버 응답 메시지 반환
+      return {
+        success: true,
+        message: responseText || '수정되었습니다.'
+      };
+    } catch (error) {
+      console.error('운행일지 수정 실패:', error);
+      set({ 
+        error: error instanceof Error ? error.message : '운행일지를 수정하는 중 오류가 발생했습니다',
+        isLoading: false
+      });
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : '운행일지를 수정하는 중 오류가 발생했습니다'
+      };
+    }
+  },
+  
+  deleteCarLog: async (logId) => {
+    try {
+      set({ isLoading: true, error: null });
+      
+      // DELETE 요청으로 운행 기록 삭제
+      const response = await fetch(`${API_BASE_URL}/carLogs/${logId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('authToken') || ''}`,
+          'Content-Type': 'application/json',
+        }
+      });
+      
+      if (!response.ok) {
+        throw new Error(`API 요청 실패: ${response.status}`);
+      }
+      
+      // 응답이 단순 문자열인 경우 처리
+      const responseText = await response.text();
+      
+      // 상태 업데이트 (로딩 완료)
+      set({ isLoading: false });
+      
+      // 서버 응답 메시지 반환
+      return {
+        success: true,
+        message: responseText || '삭제되었습니다.'
+      };
+    } catch (error) {
+      console.error('운행일지 삭제 실패:', error);
+      set({ 
+        error: error instanceof Error ? error.message : '운행일지를 삭제하는 중 오류가 발생했습니다',
+        isLoading: false
+      });
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : '운행일지를 삭제하는 중 오류가 발생했습니다'
+      };
     }
   },
   

--- a/src/lib/carLogsStore.ts
+++ b/src/lib/carLogsStore.ts
@@ -2,7 +2,6 @@ import { create } from 'zustand';
 import { CarLogResponse, CarLogsParams } from '@/types/logs';
 import { API_BASE_URL, fetchApi } from '@/lib/api';
 
-// 업데이트용 타입 정의
 interface CarLogUpdateData {
   driveType: string | null;
   driver: string;
@@ -17,7 +16,6 @@ interface CarLogsState {
   totalPages: number;
   pageSize: number;
   
-  // Actions
   fetchCarLogs: (params?: Partial<CarLogsParams>) => Promise<void>;
   updateCarLog: (logId: number, data: CarLogUpdateData) => Promise<{ success: boolean; message: string }>;
   deleteCarLog: (logId: number) => Promise<{ success: boolean; message: string }>;
@@ -63,7 +61,6 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
     try {
       set({ isLoading: true, error: null });
       
-      // PUT 요청으로 운행 기록 수정
       const response = await fetch(`${API_BASE_URL}/carLogs/${logId}`, {
         method: 'PUT',
         headers: {
@@ -77,13 +74,10 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
         throw new Error(`API 요청 실패: ${response.status}`);
       }
       
-      // 응답이 단순 문자열인 경우 처리
       const responseText = await response.text();
       
-      // 업데이트 후 목록 새로고침
       await get().fetchCarLogs();
       
-      // 서버 응답 메시지 반환
       return {
         success: true,
         message: responseText || '수정되었습니다.'
@@ -105,7 +99,6 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
     try {
       set({ isLoading: true, error: null });
       
-      // DELETE 요청으로 운행 기록 삭제
       const response = await fetch(`${API_BASE_URL}/carLogs/${logId}`, {
         method: 'DELETE',
         headers: {
@@ -121,10 +114,8 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
       // 응답이 단순 문자열인 경우 처리
       const responseText = await response.text();
       
-      // 상태 업데이트 (로딩 완료)
       set({ isLoading: false });
       
-      // 서버 응답 메시지 반환
       return {
         success: true,
         message: responseText || '삭제되었습니다.'

--- a/src/lib/carLogsStore.ts
+++ b/src/lib/carLogsStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { CarLogResponse, CarLogsParams } from '@/types/logs';
+import { CarLogResponse, CarLogsParams, DriveType } from '@/types/logs';
 import { API_BASE_URL, fetchApi } from '@/lib/api';
 
 interface CarLogUpdateData {
@@ -15,12 +15,20 @@ interface CarLogsState {
   currentPage: number;
   totalPages: number;
   pageSize: number;
+  currentFilter: {
+    vehicleNumber?: string;
+    startDate?: string;
+    endDate?: string;
+    driveType?: DriveType;
+  };
   
-  fetchCarLogs: (params?: Partial<CarLogsParams>) => Promise<void>;
+  fetchCarLogs: (params?: Partial<CarLogsParams>) => Promise<any>;
   updateCarLog: (logId: number, data: CarLogUpdateData) => Promise<{ success: boolean; message: string }>;
   deleteCarLog: (logId: number) => Promise<{ success: boolean; message: string }>;
   setPage: (page: number) => void;
   setPageSize: (size: number) => void;
+  setFilter: (filter: Partial<CarLogsState['currentFilter']>) => void;
+  resetFilter: () => void;
 }
 
 export const useCarLogsStore = create<CarLogsState>((set, get) => ({
@@ -30,30 +38,107 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
   currentPage: 0,
   totalPages: 1,
   pageSize: 10,
+  currentFilter: {
+    vehicleNumber: undefined,
+    startDate: undefined,
+    endDate: undefined,
+    driveType: undefined,
+  },
   
   fetchCarLogs: async (params) => {
     try {
       set({ isLoading: true, error: null });
       
-      const { currentPage, pageSize } = get();
+      const { currentPage, pageSize, currentFilter } = get();
       const page = params?.page !== undefined ? params.page : currentPage;
       const size = params?.size !== undefined ? params.size : pageSize;
       
-      const data = await fetchApi<CarLogResponse[]>('/carLogs', { page, size });
+      const url = `${API_BASE_URL}/carLogs?page=${page}&size=${size}`;
       
-      set({ 
-        carLogs: data,
-        currentPage: page,
-        // 백엔드가 총 페이지 수를 제공하는 경우 추가
-        // totalPages: data.totalPages || 1,
-        isLoading: false
+      const vehicleNumber = params?.vehicleNumber !== undefined ? params.vehicleNumber : currentFilter.vehicleNumber;
+      const startDate = params?.startDate !== undefined ? params.startDate : currentFilter.startDate;
+      const endDate = params?.endDate !== undefined ? params.endDate : currentFilter.endDate;
+      const driveType = params?.driveType !== undefined ? params.driveType : currentFilter.driveType;
+      
+      const requestBody: Record<string, any> = {};
+      
+      if (vehicleNumber) {
+        requestBody.mdn = vehicleNumber;
+      }
+      
+      if (startDate) {
+        const formattedStartDate = new Date(startDate);
+        formattedStartDate.setHours(0, 0, 0, 0);
+        
+        // 한국 시간대로 변환 (UTC+9)
+        const koreaTimeString = formatToKoreaTime(formattedStartDate, true);
+        requestBody.startTime = koreaTimeString;
+      }
+      
+      if (endDate) {
+        const formattedEndDate = new Date(endDate);
+        formattedEndDate.setHours(23, 59, 59, 999);
+        
+        // 한국 시간대로 변환 (UTC+9)
+        const koreaTimeString = formatToKoreaTime(formattedEndDate, false);
+        requestBody.endTime = koreaTimeString;
+      }
+      
+      if (driveType) {
+        requestBody.driveType = driveType;
+      }
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('authToken') || ''}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
       });
+      
+      if (!response.ok) {
+        throw new Error(`API 요청 실패: ${response.status}`);
+      }
+      
+      const data = await response.json();
+      
+      const content = Array.isArray(data.content) ? data.content : (Array.isArray(data) ? data : []);
+      const totalPages = data.totalPages || 1;
+      const totalElements = data.totalElements || content.length;
+      
+      if (params) {
+        const newFilter = { ...currentFilter };
+        
+        if (params.vehicleNumber !== undefined) newFilter.vehicleNumber = params.vehicleNumber;
+        if (params.startDate !== undefined) newFilter.startDate = params.startDate;
+        if (params.endDate !== undefined) newFilter.endDate = params.endDate;
+        if (params.driveType !== undefined) newFilter.driveType = params.driveType;
+        
+        set({ 
+          currentFilter: newFilter,
+          carLogs: content,
+          currentPage: page,
+          totalPages: totalPages,
+          isLoading: false
+        });
+      } else {
+        set({ 
+          carLogs: content,
+          currentPage: page,
+          totalPages: totalPages,
+          isLoading: false
+        });
+      }
+      
+      return data;
     } catch (error) {
       console.error('운행일지 데이터 가져오기 실패:', error);
       set({ 
         error: error instanceof Error ? error.message : '운행일지 데이터를 가져오는 중 오류가 발생했습니다',
         isLoading: false
       });
+      return null;
     }
   },
   
@@ -111,7 +196,6 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
         throw new Error(`API 요청 실패: ${response.status}`);
       }
       
-      // 응답이 단순 문자열인 경우 처리
       const responseText = await response.text();
       
       set({ isLoading: false });
@@ -135,11 +219,71 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
   
   setPage: (page) => {
     set({ currentPage: page });
-    get().fetchCarLogs({ page });
+    const { currentFilter } = get();
+    get().fetchCarLogs({ 
+      page,
+      vehicleNumber: currentFilter.vehicleNumber,
+      startDate: currentFilter.startDate,
+      endDate: currentFilter.endDate,
+      driveType: currentFilter.driveType
+    });
   },
   
   setPageSize: (size) => {
     set({ pageSize: size, currentPage: 0 });
-    get().fetchCarLogs({ page: 0, size });
+    const { currentFilter } = get();
+    get().fetchCarLogs({ 
+      page: 0, 
+      size,
+      vehicleNumber: currentFilter.vehicleNumber,
+      startDate: currentFilter.startDate,
+      endDate: currentFilter.endDate,
+      driveType: currentFilter.driveType
+    });
   },
-})); 
+  
+  setFilter: (filter) => {
+    const { currentFilter } = get();
+    const newFilter = { ...currentFilter, ...filter };
+    
+    // 스토어 상태 업데이트
+    set({ currentFilter: newFilter, currentPage: 0 });
+    
+    // 명시적으로 API 요청 실행
+    get().fetchCarLogs({ 
+      page: 0,
+      vehicleNumber: newFilter.vehicleNumber,
+      startDate: newFilter.startDate,
+      endDate: newFilter.endDate,
+      driveType: newFilter.driveType
+    });
+  },
+  
+  resetFilter: () => {
+    set({ 
+      currentFilter: {
+        vehicleNumber: undefined,
+        startDate: undefined,
+        endDate: undefined,
+        driveType: undefined,
+      },
+      currentPage: 0
+    });
+    get().fetchCarLogs({ page: 0 });
+  }
+}));
+
+// 한국 시간으로 변환하는 함수 추가
+const formatToKoreaTime = (date: Date, isStartDate: boolean): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  
+  // 시작일은 00:00:00.482, 종료일은 23:59:59.496으로 고정
+  const hours = isStartDate ? '00' : '23';
+  const minutes = isStartDate ? '00' : '59';
+  const seconds = isStartDate ? '00' : '59';
+  const milliseconds = isStartDate ? '482' : '496';
+  
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}`;
+}; 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,8 +31,8 @@ export function downloadExcel(data: any[], filename: string) {
     '시작 주행거리': `${formatNumber(item.startMileage)} km`,
     '종료 주행거리': `${formatNumber(item.endMileage)} km`,
     '총 주행거리': `${formatNumber(item.totalDistance)} km`,
-    '드라이브 타입': item.driveType === 'PERSONAL' ? '개인' : 
-                    item.driveType === 'CORPORATE' ? '법인' : '미등록',
+    '드라이브 타입': item.driveType === 'COMMUTE' ? '출퇴근' : 
+                  item.driveType === 'WORK' ? '업무' : '미등록',
     '드라이버': item.driver?.name || '미등록',
     '비고': item.note || '-'
   })));

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -1,4 +1,4 @@
-export type DriveType = 'PERSONAL' | 'CORPORATE' | 'UNREGISTERED';
+export type DriveType = 'COMMUTE' | 'WORK' | 'UNREGISTERED';
 
 export interface Driver {
   id: string;

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -44,4 +44,10 @@ export interface CarLogResponse {
 export interface CarLogsParams {
   page: number;
   size: number;
+  startDate?: string;
+  endDate?: string;
+  driveType?: DriveType;
+  vehicleNumber?: string;
+  driverId?: string;
+  searchTerm?: string;
 } 


### PR DESCRIPTION
close #23

## 📝 작업 내용

> 운행일지 목록, 상세보기 페이지 구현
- [X] 목록 조회 api 연결
- [X] 운행일지 상세보기 api 조회 연결
- [X] 운행일지 수정 api 연결
- [X] 운행일지 삭제 api 연결
- [X] 필터링 기능 구현

# 📍 기타 (선택)

> 페이지네이션 기능 추가 
- 백엔드 api에서 페이지네이션 정보도 반환되도록 함께 수정 진행했습니다.
- 자동차 페이지에서 페이지네이션 추가할 경우 백엔드 api수정이 필요합니다.