### PR TITLE
[#42] feat: 공지 사항 관련 페이지 추가

### DIFF
--- a/src/app/announcements/[id]/page.tsx
+++ b/src/app/announcements/[id]/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useTheme } from "@/contexts/ThemeContext";
+import PageHeader from "@/components/common/PageHeader";
+import { useAnnouncementStore } from "@/lib/announcementStore";
+import { AnnouncementType } from "@/types/announcement";
+import { ExclamationTriangleIcon, BellIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { useAuthStore } from "@/lib/authStore";
+import { use } from "react";
+
+export default function AnnouncementDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { currentTheme } = useTheme();
+  const router = useRouter();
+  const { isAuthenticated } = useAuthStore();
+  const resolvedParams = use(params);
+  const announcementId = parseInt(resolvedParams.id);
+  
+  console.log('URL 파라미터 ID:', resolvedParams.id);
+  console.log('파싱된 ID:', announcementId);
+  
+  // 공지 사항 데이터 가져오기
+  const { 
+    announcementDetail, 
+    announcements,
+    isLoading, 
+    error, 
+    fetchAnnouncementDetail,
+    fetchAnnouncements
+  } = useAnnouncementStore();
+  
+  // 컴포넌트 마운트 시 데이터 로드
+  useEffect(() => {
+    if (isNaN(announcementId)) {
+      console.error('유효하지 않은 ID입니다:', resolvedParams.id);
+      return;
+    }
+    
+    console.log('공지사항 상세 정보 요청 ID:', announcementId);
+    fetchAnnouncementDetail(announcementId);
+    fetchAnnouncements(0, 5); // 상세 페이지 하단에 표시할 최신 5개 공지사항
+  }, [fetchAnnouncementDetail, fetchAnnouncements, announcementId, resolvedParams.id]);
+  
+  // 로그인 상태 확인
+  useEffect(() => {
+    const isAuthed = useAuthStore.getState().checkAuth();
+    
+    if (!isAuthed) {
+      console.log('공지사항 상세: 인증되지 않은 사용자 감지. 로그인 페이지로 리다이렉트합니다.');
+      router.push('/login');
+    }
+  }, [router]);
+  
+  // 로그인되지 않았거나 로딩 중인 경우 로딩 화면 표시
+  if (!isAuthenticated) {
+    return (
+      <div className={`min-h-screen ${currentTheme.background} flex items-center justify-center`}>
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className={`text-lg ${currentTheme.text}`}>로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="p-8">
+      <PageHeader title="공지사항 상세" />
+      
+      {/* 뒤로가기 버튼 */}
+      <button 
+        onClick={() => router.push('/announcements')}
+        className={`flex items-center ${currentTheme.activeText} hover:opacity-80 mb-4`}
+      >
+        <ArrowLeftIcon className="h-4 w-4 mr-1" />
+        <span>목록으로 돌아가기</span>
+      </button>
+      
+      {/* 공지사항 상세 내용 */}
+      {isLoading ? (
+        <div className={`${currentTheme.cardBg} p-6 rounded-xl shadow-sm ${currentTheme.border} mb-6`}>
+          <div className="text-center py-8">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+            <p className={`text-lg ${currentTheme.text}`}>로딩 중...</p>
+          </div>
+        </div>
+      ) : error ? (
+        <div className={`${currentTheme.cardBg} p-6 rounded-xl shadow-sm ${currentTheme.border} mb-6`}>
+          <div className="text-center py-8">
+            <p className={`text-lg ${currentTheme.text} text-red-500`}>{error}</p>
+          </div>
+        </div>
+      ) : announcementDetail ? (
+        <div className={`${currentTheme.cardBg} p-6 rounded-xl shadow-sm ${currentTheme.border} mb-6`}>
+          <div className={`p-4 rounded-lg ${
+            announcementDetail.type === AnnouncementType.ALERT
+              ? 'bg-amber-50 border border-amber-200'
+              : `${currentTheme.activeBg}`
+          }`}>
+            <div className="flex items-start mb-4">
+              {announcementDetail.type === AnnouncementType.ALERT ? (
+                <ExclamationTriangleIcon className="h-6 w-6 text-amber-500 mr-3 flex-shrink-0 mt-0.5" />
+              ) : (
+                <BellIcon className="h-6 w-6 text-blue-500 mr-3 flex-shrink-0 mt-0.5" />
+              )}
+              <div>
+                <h2 className={`text-xl font-semibold ${announcementDetail.type === AnnouncementType.ALERT ? 'text-black dark:text-black' : currentTheme.text}`}>
+                  {announcementDetail.title}
+                </h2>
+                <p className={`text-sm ${announcementDetail.type === AnnouncementType.ALERT ? 'text-black dark:text-black mt-1' : `${currentTheme.subtext} mt-1`}`}>
+                  {announcementDetail.createdAt}
+                </p>
+              </div>
+            </div>
+            <div className={`mt-4 ${announcementDetail.type === AnnouncementType.ALERT ? 'text-black dark:text-black' : currentTheme.text}`}>
+              {announcementDetail.content.split('\n').map((line, index) => (
+                <p key={index} className="mb-2">{line}</p>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className={`${currentTheme.cardBg} p-6 rounded-xl shadow-sm ${currentTheme.border} mb-6`}>
+          <div className="text-center py-8">
+            <p className={`text-lg ${currentTheme.text}`}>공지사항을 찾을 수 없습니다.</p>
+          </div>
+        </div>
+      )}
+      
+      {/* 다른 공지사항 목록 */}
+      <div className={`${currentTheme.cardBg} p-6 rounded-xl shadow-sm ${currentTheme.border}`}>
+        <h3 className={`text-lg font-medium ${currentTheme.text} mb-4`}>다른 공지사항</h3>
+        
+        {announcements.length > 0 ? (
+          <div className="space-y-3">
+            {announcements
+              .filter(announcement => announcement.id !== announcementId)
+              .map((announcement) => (
+                <div 
+                  key={announcement.id}
+                  className={`p-3 rounded-lg cursor-pointer transition-colors ${
+                    announcement.type === AnnouncementType.ALERT
+                      ? 'bg-amber-50 border border-amber-200 hover:bg-amber-100'
+                      : `${currentTheme.activeBg} hover:bg-opacity-80`
+                  }`}
+                  onClick={() => {
+                    console.log(`공지사항 ID ${announcement.id}로 이동합니다.`);
+                    router.push(`/announcements/${announcement.id}`);
+                  }}
+                  data-announcement-id={announcement.id}
+                >
+                  <div className="flex items-start">
+                    {announcement.type === AnnouncementType.ALERT ? (
+                      <ExclamationTriangleIcon className="h-5 w-5 text-amber-500 mr-2 flex-shrink-0 mt-0.5" />
+                    ) : (
+                      <BellIcon className="h-5 w-5 text-blue-500 mr-2 flex-shrink-0 mt-0.5" />
+                    )}
+                    <div className="flex-1">
+                      <h3 className={`font-medium ${announcement.type === AnnouncementType.ALERT ? 'text-black dark:text-black' : currentTheme.text}`}>
+                        {announcement.title}
+                      </h3>
+                      <p className={`text-xs ${announcement.type === AnnouncementType.ALERT ? 'text-black dark:text-black mt-1' : currentTheme.subtext} mt-1`}>
+                        {announcement.createdAt}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+          </div>
+        ) : (
+          <p className={`text-center py-4 text-sm ${currentTheme.subtext}`}>다른 공지사항이 없습니다.</p>
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/src/app/announcements/page.tsx
+++ b/src/app/announcements/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useTheme } from "@/contexts/ThemeContext";
+import PageHeader from "@/components/common/PageHeader";
+import { useAnnouncementStore } from "@/lib/announcementStore";
+import { AnnouncementType } from "@/types/announcement";
+import { ExclamationTriangleIcon, BellIcon } from "@heroicons/react/24/outline";
+import { useAuthStore } from "@/lib/authStore";
+import { use } from "react";
+
+export default function AnnouncementsPage({ params }: { params: Promise<{ page?: string }> }) {
+  const { currentTheme } = useTheme();
+  const router = useRouter();
+  const { isAuthenticated } = useAuthStore();
+  const resolvedParams = use(params);
+  const page = resolvedParams.page ? parseInt(resolvedParams.page) : 0;
+  
+  // 공지 사항 데이터 가져오기
+  const { 
+    announcements, 
+    totalElements, 
+    totalPages, 
+    currentPage, 
+    pageSize, 
+    isLoading, 
+    error, 
+    fetchAnnouncements 
+  } = useAnnouncementStore();
+  
+  // 페이지 변경 핸들러
+  const handlePageChange = (page: number) => {
+    fetchAnnouncements(page, pageSize);
+  };
+  
+  // 공지 사항 상세 페이지로 이동
+  const handleAnnouncementClick = (id: number) => {
+    console.log(`공지사항 ID ${id}로 이동합니다.`);
+    if (id === undefined || id === null) {
+      console.error('공지사항 ID가 유효하지 않습니다.');
+      return;
+    }
+    router.push(`/announcements/${id}`);
+  };
+  
+  // 컴포넌트 마운트 시 데이터 로드
+  useEffect(() => {
+    fetchAnnouncements(page, pageSize);
+  }, [fetchAnnouncements, page, pageSize]);
+  
+  // 공지사항 데이터 로드 후 ID 확인
+  useEffect(() => {
+    if (announcements.length > 0) {
+      console.log('로드된 공지사항:', announcements);
+      announcements.forEach(announcement => {
+        console.log(`공지사항 ID: ${announcement.id}, 제목: ${announcement.title}`);
+      });
+    }
+  }, [announcements]);
+  
+  // 로그인 상태 확인
+  useEffect(() => {
+    const isAuthed = useAuthStore.getState().checkAuth();
+    
+    if (!isAuthed) {
+      console.log('공지사항: 인증되지 않은 사용자 감지. 로그인 페이지로 리다이렉트합니다.');
+      router.push('/login');
+    }
+  }, [router]);
+  
+  // 로그인되지 않았거나 로딩 중인 경우 로딩 화면 표시
+  if (!isAuthenticated) {
+    return (
+      <div className={`min-h-screen ${currentTheme.background} flex items-center justify-center`}>
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className={`text-lg ${currentTheme.text}`}>로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="p-8">
+      <PageHeader title="공지사항" />
+      
+      {/* 공지사항 목록 */}
+      <div className={`${currentTheme.cardBg} p-6 rounded-xl shadow-sm ${currentTheme.border} mb-6`}>
+        {isLoading ? (
+          <div className="text-center py-8">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+            <p className={`text-lg ${currentTheme.text}`}>로딩 중...</p>
+          </div>
+        ) : error ? (
+          <div className="text-center py-8">
+            <p className={`text-lg ${currentTheme.text} text-red-500`}>{error}</p>
+          </div>
+        ) : announcements.length > 0 ? (
+          <>
+            <div className="space-y-4">
+              {announcements.map((announcement) => (
+                <div 
+                  key={announcement.id}
+                  className={`p-4 rounded-lg cursor-pointer transition-colors ${
+                    announcement.type === AnnouncementType.ALERT
+                      ? 'bg-amber-50 border border-amber-200 hover:bg-amber-100'
+                      : `${currentTheme.activeBg} hover:bg-opacity-80`
+                  }`}
+                  onClick={() => handleAnnouncementClick(announcement.id)}
+                  data-announcement-id={announcement.id}
+                >
+                  <div className="flex items-start">
+                    {announcement.type === AnnouncementType.ALERT ? (
+                      <ExclamationTriangleIcon className="h-5 w-5 text-amber-500 mr-3 flex-shrink-0 mt-0.5" />
+                    ) : (
+                      <BellIcon className="h-5 w-5 text-blue-500 mr-3 flex-shrink-0 mt-0.5" />
+                    )}
+                    <div className="flex-1">
+                      <h3 className={`font-medium ${announcement.type === AnnouncementType.ALERT ? 'text-black dark:text-black' : currentTheme.text}`}>
+                        {announcement.title}
+                      </h3>
+                      <p className={`text-sm ${announcement.type === AnnouncementType.ALERT ? 'text-black dark:text-black mt-1' : `${currentTheme.subtext} mt-1`}`}>
+                        {announcement.content.length > 100 
+                          ? `${announcement.content.substring(0, 100)}...` 
+                          : announcement.content}
+                      </p>
+                      <p className={`text-xs ${announcement.type === AnnouncementType.ALERT ? 'text-black dark:text-black mt-2' : currentTheme.subtext} mt-2`}>
+                        {announcement.createdAt}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            
+            {/* 페이지네이션 */}
+            {totalPages > 1 && (
+              <div className="flex justify-center mt-6">
+                <div className="flex space-x-2">
+                  {Array.from({ length: totalPages }, (_, i) => (
+                    <button
+                      key={i}
+                      className={`px-3 py-1 rounded ${
+                        currentPage === i
+                          ? `${currentTheme.activeBg} ${currentTheme.activeText}`
+                          : `${currentTheme.subtext} hover:${currentTheme.activeBg} hover:${currentTheme.activeText}`
+                      }`}
+                      onClick={() => handlePageChange(i)}
+                    >
+                      {i + 1}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="text-center py-8">
+            <p className={`text-lg ${currentTheme.text}`}>공지사항이 없습니다.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -32,6 +32,8 @@ import { useCarOverviewStore } from "@/lib/carOverviewStore";
 import { useUserStore } from "@/lib/userStore";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/lib/authStore";
+import { useAnnouncementStore } from "@/lib/announcementStore";
+import { AnnouncementType } from "@/types/announcement";
 
 ChartJS.register(
   CategoryScale,
@@ -52,30 +54,6 @@ const userInfo = {
   lastLogin: "2023-06-15 09:30",
 };
 
-// 공지사항 데이터
-const notices = [
-  {
-    id: 1,
-    title: "시스템 점검 안내",
-    content: "6월 20일 새벽 2시부터 4시까지 시스템 점검이 있을 예정입니다.",
-    date: "2023-06-15",
-    isImportant: true,
-  },
-  {
-    id: 2,
-    title: "신규 기능 안내",
-    content: "차량 실시간 위치 추적 기능이 추가되었습니다.",
-    date: "2023-06-10",
-    isImportant: false,
-  },
-  {
-    id: 3,
-    title: "보고서 양식 변경",
-    content: "월간 운행 보고서 양식이 변경되었습니다. 새로운 양식을 확인해주세요.",
-    date: "2023-06-05",
-    isImportant: false,
-  },
-];
 
 // 월간 데이터를 상수로 유지
 const monthlyData = {
@@ -129,11 +107,15 @@ export default function DashboardPage() {
   // Get employee data from user store
   const { users, isLoading: isEmployeeLoading, fetchUsersOfCompany } = useUserStore();
   
+  // Get announcements data from store
+  const { announcements, isLoading: isAnnouncementLoading, fetchAnnouncements } = useAnnouncementStore();
+  
   // Fetch data on component mount
   useEffect(() => {
     fetchOverview();
     fetchUsersOfCompany();
-  }, [fetchOverview, fetchUsersOfCompany]);
+    fetchAnnouncements(0, 3); // 대시보드에서는 최신 3개만 표시
+  }, [fetchOverview, fetchUsersOfCompany, fetchAnnouncements]);
   
   // Prepare car status data for chart - moved inside component
   const vehicleStatusData = {
@@ -238,34 +220,43 @@ export default function DashboardPage() {
             <div className="mt-4">
               <div className="flex justify-between items-center mb-4">
                 <h3 className={`text-base font-medium ${currentTheme.text}`}>공지사항</h3>
-                <button className={`text-sm ${currentTheme.activeText} hover:opacity-80 font-medium flex items-center`}>
+                <Link href="/announcements" className={`text-sm ${currentTheme.activeText} hover:opacity-80 font-medium flex items-center`}>
                   <BellIcon className="h-4 w-4 mr-1" />
                   전체보기
-                </button>
+                </Link>
               </div>
               <div className="space-y-3">
-                {notices.map((notice) => (
-                  <div 
-                    key={notice.id} 
-                    className={`p-3 rounded-lg ${notice.isImportant 
-                      ? 'bg-amber-50 border border-amber-200' 
-                      : `${currentTheme.activeBg} hover:bg-opacity-80 transition-colors`
-                    }`}
-                  >
-                    <div className="flex justify-between items-start">
-                      <div className="flex items-start">
-                        {notice.isImportant && (
-                          <ExclamationTriangleIcon className="h-5 w-5 text-amber-500 mr-2 flex-shrink-0 mt-0.5" />
-                        )}
-                        <div>
-                          <h3 className={`font-medium ${notice.isImportant ? 'text-black dark:text-black' : currentTheme.text}`}>{notice.title}</h3>
-                          <p className={`text-sm ${notice.isImportant ? 'text-black dark:text-black mt-1' : `${currentTheme.subtext} mt-1`}`}>{notice.content}</p>
-                        </div>
-                      </div>
-                      <span className={`text-xs ${notice.isImportant ? 'text-black dark:text-black' : currentTheme.subtext} whitespace-nowrap ml-4`}>{notice.date}</span>
-                    </div>
+                {isAnnouncementLoading ? (
+                  <div className="text-center py-4">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600 mx-auto mb-2"></div>
+                    <p className={`text-sm ${currentTheme.subtext}`}>로딩 중...</p>
                   </div>
-                ))}
+                ) : announcements.length > 0 ? (
+                  announcements.map((notice) => (
+                    <div 
+                      key={notice.id} 
+                      className={`p-3 rounded-lg ${notice.type === AnnouncementType.ALERT
+                        ? 'bg-amber-50 border border-amber-200' 
+                        : `${currentTheme.activeBg} hover:bg-opacity-80 transition-colors`
+                      }`}
+                    >
+                      <div className="flex justify-between items-start">
+                        <div className="flex items-start">
+                          {notice.type === AnnouncementType.ALERT && (
+                            <ExclamationTriangleIcon className="h-5 w-5 text-amber-500 mr-2 flex-shrink-0 mt-0.5" />
+                          )}
+                          <div>
+                            <h3 className={`font-medium ${notice.type === AnnouncementType.ALERT ? 'text-black dark:text-black' : currentTheme.text}`}>{notice.title}</h3>
+                            <p className={`text-sm ${notice.type === AnnouncementType.ALERT ? 'text-black dark:text-black mt-1' : `${currentTheme.subtext} mt-1`}`}>{notice.content}</p>
+                          </div>
+                        </div>
+                        <span className={`text-xs ${notice.type === AnnouncementType.ALERT ? 'text-black dark:text-black' : currentTheme.subtext} whitespace-nowrap ml-4`}>{notice.createdAt}</span>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <p className={`text-center py-4 text-sm ${currentTheme.subtext}`}>공지사항이 없습니다.</p>
+                )}
               </div>
             </div>
           </div>

--- a/src/lib/announcementStore.ts
+++ b/src/lib/announcementStore.ts
@@ -1,0 +1,88 @@
+import { create } from 'zustand';
+import { fetchApi } from './api';
+import { Announcement, AnnouncementsResponse, AnnouncementDetailResponse } from '@/types/announcement';
+
+interface AnnouncementState {
+  announcements: Announcement[];
+  announcementDetail: AnnouncementDetailResponse | null;
+  totalElements: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+  isLoading: boolean;
+  error: string | null;
+  fetchAnnouncements: (page?: number, size?: number) => Promise<void>;
+  fetchAnnouncementDetail: (id: number) => Promise<void>;
+}
+
+export const useAnnouncementStore = create<AnnouncementState>((set) => ({
+  announcements: [],
+  announcementDetail: null,
+  totalElements: 0,
+  totalPages: 0,
+  currentPage: 0,
+  pageSize: 10,
+  isLoading: false,
+  error: null,
+  
+  // 공지 사항 목록 조회
+  fetchAnnouncements: async (page = 0, size = 10) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetchApi<AnnouncementsResponse>('/api/announcement', {
+        page,
+        size
+      });
+      
+      // ID 값이 없는 경우 기본 ID 값을 설정
+      const processedAnnouncements = response.content.map((announcement, index) => ({
+        ...announcement,
+        id: announcement.id || index + 1 // ID가 없는 경우 인덱스+1을 ID로 사용
+      }));
+      
+      console.log('API 응답:', response);
+      console.log('처리된 공지사항:', processedAnnouncements);
+      
+      set({
+        announcements: processedAnnouncements,
+        totalElements: response.totalElements,
+        totalPages: response.totalPages,
+        currentPage: response.number,
+        pageSize: response.size,
+        isLoading: false
+      });
+    } catch (error) {
+      set({ 
+        error: error instanceof Error ? error.message : '공지 사항을 불러오는 중 오류가 발생했습니다.',
+        isLoading: false 
+      });
+    }
+  },
+  
+  // 공지 사항 상세 조회
+  fetchAnnouncementDetail: async (id: number) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetchApi<AnnouncementDetailResponse>(`/api/announcement/${id}`);
+      
+      // ID 값이 없는 경우 기본 ID 값을 설정
+      const processedDetail = {
+        ...response,
+        id: response.id || id // ID가 없는 경우 URL 파라미터의 ID를 사용
+      };
+      
+      console.log('상세 API 응답:', response);
+      console.log('처리된 상세 공지사항:', processedDetail);
+      
+      set({
+        announcementDetail: processedDetail,
+        isLoading: false
+      });
+    } catch (error) {
+      set({ 
+        error: error instanceof Error ? error.message : '공지 사항 상세 정보를 불러오는 중 오류가 발생했습니다.',
+        isLoading: false 
+      });
+    }
+  }
+})); 

--- a/src/lib/announcementStore.ts
+++ b/src/lib/announcementStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { fetchApi } from './api';
-import { Announcement, AnnouncementsResponse, AnnouncementDetailResponse } from '@/types/announcement';
+import { Announcement, AnnouncementsResponse, AnnouncementDetailResponse, AnnouncementApiResponse, AnnouncementType } from '@/types/announcement';
 
 interface AnnouncementState {
   announcements: Announcement[];
@@ -34,13 +34,22 @@ export const useAnnouncementStore = create<AnnouncementState>((set) => ({
         size
       });
       
-      // ID 값이 없는 경우 기본 ID 값을 설정
-      const processedAnnouncements = response.content.map((announcement, index) => ({
-        ...announcement,
-        id: announcement.id || index + 1 // ID가 없는 경우 인덱스+1을 ID로 사용
-      }));
+      console.log('API 원본 응답:', response);
       
-      console.log('API 응답:', response);
+      // announcementId를 id로 매핑하여 처리
+      const processedAnnouncements = response.content.map((item, index) => {
+        // API 응답 구조 확인 및 로깅
+        console.log(`항목 ${index}:`, item);
+        
+        return {
+          id: item.announcementId || item.id || index + 1, // announcementId 또는 id가 없는 경우 인덱스+1 사용
+          title: item.title,
+          content: item.content,
+          type: item.announcementType === 'ALERT' ? AnnouncementType.ALERT : AnnouncementType.INFO,
+          createdAt: item.createdAt
+        } as Announcement;
+      });
+      
       console.log('처리된 공지사항:', processedAnnouncements);
       
       set({
@@ -52,6 +61,7 @@ export const useAnnouncementStore = create<AnnouncementState>((set) => ({
         isLoading: false
       });
     } catch (error) {
+      console.error('공지사항 조회 오류:', error);
       set({ 
         error: error instanceof Error ? error.message : '공지 사항을 불러오는 중 오류가 발생했습니다.',
         isLoading: false 
@@ -63,15 +73,19 @@ export const useAnnouncementStore = create<AnnouncementState>((set) => ({
   fetchAnnouncementDetail: async (id: number) => {
     set({ isLoading: true, error: null });
     try {
-      const response = await fetchApi<AnnouncementDetailResponse>(`/api/announcement/${id}`);
+      const response = await fetchApi<AnnouncementApiResponse>(`/api/announcement/${id}`);
       
-      // ID 값이 없는 경우 기본 ID 값을 설정
+      console.log('상세 API 원본 응답:', response);
+      
+      // announcementId를 id로 매핑하여 처리
       const processedDetail = {
-        ...response,
-        id: response.id || id // ID가 없는 경우 URL 파라미터의 ID를 사용
-      };
+        id: response.announcementId || response.id || id, // announcementId 또는 id가 없는 경우 URL 파라미터 ID 사용
+        title: response.title,
+        content: response.content,
+        type: response.announcementType === 'ALERT' ? AnnouncementType.ALERT : AnnouncementType.INFO,
+        createdAt: response.createdAt
+      } as AnnouncementDetailResponse;
       
-      console.log('상세 API 응답:', response);
       console.log('처리된 상세 공지사항:', processedDetail);
       
       set({
@@ -79,6 +93,7 @@ export const useAnnouncementStore = create<AnnouncementState>((set) => ({
         isLoading: false
       });
     } catch (error) {
+      console.error('공지사항 상세 조회 오류:', error);
       set({ 
         error: error instanceof Error ? error.message : '공지 사항 상세 정보를 불러오는 중 오류가 발생했습니다.',
         isLoading: false 

--- a/src/types/announcement.ts
+++ b/src/types/announcement.ts
@@ -1,0 +1,32 @@
+// 공지 사항 타입 정의
+export enum AnnouncementType {
+  ALERT = 'ALERT',
+  INFO = 'INFO'
+}
+
+// 공지 사항 목록 조회 응답 타입
+export interface Announcement {
+  id: number;
+  title: string;
+  content: string;
+  type: AnnouncementType;
+  createdAt: string;
+}
+
+// 공지 사항 목록 페이지네이션 응답 타입
+export interface AnnouncementsResponse {
+  content: Announcement[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+// 공지 사항 상세 조회 응답 타입
+export interface AnnouncementDetailResponse {
+  id: number;
+  title: string;
+  content: string;
+  type: AnnouncementType;
+  createdAt: string;
+} 

--- a/src/types/announcement.ts
+++ b/src/types/announcement.ts
@@ -4,7 +4,17 @@ export enum AnnouncementType {
   INFO = 'INFO'
 }
 
-// 공지 사항 목록 조회 응답 타입
+// API 응답에서 사용하는 백엔드 데이터 타입
+export interface AnnouncementApiResponse {
+  announcementId?: number;
+  id?: number;
+  title: string;
+  content: string;
+  announcementType: string;
+  createdAt: string;
+}
+
+// 프론트엔드에서 사용하는 공지사항 타입
 export interface Announcement {
   id: number;
   title: string;
@@ -15,7 +25,7 @@ export interface Announcement {
 
 // 공지 사항 목록 페이지네이션 응답 타입
 export interface AnnouncementsResponse {
-  content: Announcement[];
+  content: AnnouncementApiResponse[];
   totalElements: number;
   totalPages: number;
   size: number;


### PR DESCRIPTION
close #42

## 📝 작업 내용

대시보드의 공지 사항 화면, 공지 사항 리스트, 공지 사항 상세 페이지 작업을 했습니다.

<img width="1251" alt="스크린샷 2025-04-08 오후 12 49 31" src="https://github.com/user-attachments/assets/a12f3016-191a-4117-ade9-82c944000d74" />
<img width="1234" alt="스크린샷 2025-04-08 오후 12 50 07" src="https://github.com/user-attachments/assets/ab16efd2-7d90-4a91-82d6-4f2532090cde" />
<img width="1192" alt="스크린샷 2025-04-08 오후 12 51 18" src="https://github.com/user-attachments/assets/224d002b-aff3-405d-8c52-0b0c7321b5f9" />

