### PR TITLE
[#86] 페이지 새로고침시 login 화면 노출 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@headlessui/react": "^2.2.1",
         "@heroicons/react": "^2.2.0",
+        "@types/js-cookie": "^3.0.6",
         "chart.js": "^4.4.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.6.3",
+        "js-cookie": "^3.0.5",
         "lucide-react": "^0.487.0",
         "next": "15.2.4",
         "react": "^19.0.0",
@@ -1358,6 +1360,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -4165,6 +4173,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@headlessui/react": "^2.2.1",
     "@heroicons/react": "^2.2.0",
+    "@types/js-cookie": "^3.0.6",
     "chart.js": "^4.4.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.6.3",
+    "js-cookie": "^3.0.5",
     "lucide-react": "^0.487.0",
     "next": "15.2.4",
     "react": "^19.0.0",

--- a/src/app/monitoring/page.tsx
+++ b/src/app/monitoring/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/lib/authStore';
 import { useTheme } from '@/contexts/ThemeContext';
 import { 
@@ -192,6 +192,7 @@ function VehicleSidebar({
 
 export default function MonitoringPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { isAuthenticated } = useAuthStore();
   const { currentTheme } = useTheme(); 
   const [wsConnected, setWsConnected] = useState(false);
@@ -481,14 +482,16 @@ export default function MonitoringPage() {
     connectWebSocket();
   };
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      router.push('/login');
-    }
-  }, [isAuthenticated, router]);
-
+  // 인증되지 않은 경우 로딩 화면 표시
   if (!isAuthenticated) {
-    return null;
+    return (
+      <div className={`${currentTheme.background} min-h-screen flex items-center justify-center`}>
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className={`text-lg ${currentTheme.text}`}>인증 확인 중...</p>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -60,9 +60,20 @@ export function middleware(request: NextRequest) {
   const needsAuth = PROTECTED_PATHS.some(path => pathname === path || pathname.startsWith(`${path}/`));
   if (needsAuth && !isAuthenticated) {
     console.log(`[Middleware] 인증되지 않은 사용자가 보호된 경로 접근: ${pathname} -> /login으로 리다이렉트`);
+    
+    // 로그인 페이지로 리다이렉트할 때 특별한 쿼리 파라미터 추가
     const url = new URL('/login', request.url);
     url.searchParams.set('callbackUrl', encodeURI(pathname));
-    return NextResponse.redirect(url);
+    url.searchParams.set('silent', 'true'); // 내부 처리용 플래그
+    
+    // 리다이렉트 응답 생성
+    const response = NextResponse.redirect(url);
+    
+    // 응답 헤더에 인증 상태 정보 추가
+    response.headers.set('x-authenticated', 'false');
+    response.headers.set('x-redirect', 'true');
+    
+    return response;
   }
   
   // 인증된 사용자가 로그인/회원가입 페이지에 접근하면 대시보드로 리다이렉트


### PR DESCRIPTION
close #86 

[#86] fix: 페이지 새로고침시 login 화면 노출 수정

## 📝 작업 내용

> 페이지 새로고침시 Login 페이지 화면 노출을 하지 않도록 변경합니다.

페이지 새로고침시 dashboard로 넘어가게 되는데 현재 페이지에 남아있도록 수정합니다.
ex) /vehicles -> /dashboard
=> /vehicles -> /vehicles

