### PR TITLE
[#89] fix: 프론트 QA

### DIFF
--- a/src/app/companies/page.tsx
+++ b/src/app/companies/page.tsx
@@ -65,7 +65,7 @@ export default function CompaniesPage() {
         <div className="flex justify-between items-center mb-8">
           <PageHeader 
             title="업체 정보" 
-            description="위카 주식회사 정보와 직원 목록을 관리합니다" 
+            description="회사 정보와 직원 목록을 관리합니다" 
           />
           
           <div className="hidden md:flex space-x-2">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -459,6 +459,7 @@ export default function DashboardPage() {
                       },
                       ticks: {
                         color: currentTheme.mode === 'dark' ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)',
+                        callback: (value) => `${Number(value).toLocaleString()} km`
                       },
                     },
                     x: {
@@ -474,6 +475,11 @@ export default function DashboardPage() {
                     legend: {
                       display: false,
                     },
+                    tooltip: {
+                      callbacks: {
+                        label: (context) => `${Number(context.raw).toLocaleString()} km`
+                      }
+                    }
                   },
                 }}
               />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   MapIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  ChartBarIcon,
 } from "@heroicons/react/24/outline";
 import { useTheme, themes } from "@/contexts/ThemeContext";
 import { useAuthStore } from "@/lib/authStore";
@@ -25,6 +26,7 @@ const navigation = [
   { name: "차량", href: "/vehicles", icon: TruckIcon },
   { name: "운행일지", href: "/logs", icon: ClipboardDocumentListIcon },
   { name: "실시간 관제", href: "/monitoring", icon: MapIcon },
+  { name: "분석", href: "/statistics", icon: ChartBarIcon },
   { name: "회사", href: "/companies", icon: BuildingOfficeIcon },
 ];
 

--- a/src/lib/carLogsStore.ts
+++ b/src/lib/carLogsStore.ts
@@ -97,37 +97,29 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
       const endDate = params?.endDate !== undefined ? params.endDate : currentFilter.endDate;
       const driveType = params?.driveType !== undefined ? params.driveType : currentFilter.driveType;
       
-      const requestBody: Record<string, any> = {};
+      // 쿼리 파라미터 구성
+      const queryParams = new URLSearchParams();
+      queryParams.append('page', page.toString());
+      queryParams.append('size', size.toString());
       
       if (vehicleNumber) {
-        requestBody.mdn = vehicleNumber;
+        queryParams.append('mdn', vehicleNumber);
       }
       
       if (startDate) {
-        const formattedStartDate = new Date(startDate);
-        formattedStartDate.setHours(0, 0, 0, 0);
-        
-        // 한국 시간대로 변환 (UTC+9)
-        const koreaTimeString = formatToKoreaTime(formattedStartDate, true);
-        requestBody.startTime = koreaTimeString;
+        queryParams.append('from', startDate);
       }
       
       if (endDate) {
-        const formattedEndDate = new Date(endDate);
-        formattedEndDate.setHours(23, 59, 59, 999);
-        
-        // 한국 시간대로 변환 (UTC+9)
-        const koreaTimeString = formatToKoreaTime(formattedEndDate, false);
-        requestBody.endTime = koreaTimeString;
+        queryParams.append('to', endDate);
       }
       
       if (driveType) {
-        requestBody.driveType = driveType;
+        queryParams.append('driveType', driveType);
       }
       
-      const data = await fetchApi<{data: any, message: string, statusCode: number}>(`/api/carLogs?page=${page}&size=${size}`, undefined, {
-        method: 'POST',
-        body: JSON.stringify(requestBody)
+      const data = await fetchApi<{data: any, message: string, statusCode: number}>(`/api/carLogs?${queryParams.toString()}`, undefined, {
+        method: 'GET'
       });
       
       // 새로운 API 응답 형식 처리 (data 필드에 실제 데이터가 있음)
@@ -180,14 +172,14 @@ export const useCarLogsStore = create<CarLogsState>((set, get) => ({
         method: 'GET'
       });
       
-      // 새로운 API 응답 형식 처리 (data 필드에 실제 데이터가 있음)
+      // 새로운 API 응답 형식 처리
       const data = response.data || response;
       
       set({ 
         stats: {
           totalMileage: data.totalMileage || 0,
           carLogsCount: data.carLogsCount || "0",
-          monthlyMileages: data.monthlyMileages || []
+          monthlyMileages: Array.isArray(data) ? data : []
         },
         isLoading: false
       });


### PR DESCRIPTION
close #90

## 개요
프론트엔드 QA 과정 중 발견된 수정사항 및 기능 개선을 반영했습니다.

## 작업 상세

### 1. 회사 페이지 소개 수정
- 기존 소개 문구를 `"위카 주식회사 정보와 직원 목록을 관리합니다"` → `"회사 정보와 직원 목록을 관리합니다"`로 수정

### 2. 대시보드 바 차트 수정
- 기존에 못불러오던 문제해결
- y축 숫자 포맷을 `,`(쉼표) 추가해 가독성 향상 (`12345` → `12,345 km`)
- 툴팁(tooltip)에서도 숫자에 `,`(쉼표) 포맷 적용하여 일관성 있게 표시

### 3. 주행일지 조회 필터 수정
- 주행일지 조회 시
  - **POST** 방식 → **GET** 방식으로 변경
  - 파라미터를 URL에 쿼리 스트링(`?page=1&size=10&mdn=xxx&from=yyyy-mm-dd&to=yyyy-mm-dd&driveType=xxx`)으로 전달
- 필터 날짜 처리 시 한국 시간(UTC+9)으로 포맷 처리 후 쿼리 반영
- API 응답 데이터 처리 개선
